### PR TITLE
Make server port configurable through environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,11 @@ WORKDIR /app
 COPY --from=builder /app/web-server .
 COPY --from=builder /app/.env.example .env
 
+# Set default port
+ENV PORT=8080
+
 # Expose port
-EXPOSE 8080
+EXPOSE ${PORT}
 
 # Command to run
 CMD ["./web-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,9 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8080:8080"
+      - "${PORT:-8080}:${PORT:-8080}"
     environment:
+      - PORT=${PORT:-8080}
       - ENV=production
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/go_server_db?schema=public
     depends_on:

--- a/main.go
+++ b/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"log"
-	_ "web-server/docs" // swagger docs
-	"web-server/internal/infrastructure/server"
+"log"
+"os"
+_ "web-server/docs" // swagger docs
+"web-server/internal/infrastructure/server"
 
-	_ "github.com/swaggo/files"
-	_ "github.com/swaggo/gin-swagger"
+_ "github.com/swaggo/files"
+_ "github.com/swaggo/gin-swagger"
 )
 
 // @title Web Server API
@@ -15,6 +16,11 @@ import (
 // @host localhost:8080
 // @BasePath /api/v1
 func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080" // Default port if not specified
+	}
+
 	srv := server.NewServer()
-	log.Fatal(srv.Start(":8080"))
+	log.Fatal(srv.Start(":" + port))
 }

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 "log"
 "os"
-_ "web-server/docs" // swagger docs
+_ "web-server/docs"
 "web-server/internal/infrastructure/server"
 
 _ "github.com/swaggo/files"


### PR DESCRIPTION
Issue
The server port number specified in the .env file was not being respected, as the port was hardcoded to 8080 in multiple places. This made it impossible to run multiple instances on different ports or customize the port through configuration.

Fixed #1 

Changes
main.go: Read port from environment variable with fallback to 8080

port := os.Getenv("PORT")
if port == "" {
    port = "8080" // Default port if not specified
}
Dockerfile: Make port configurable via environment variable

ENV PORT=8080
EXPOSE ${PORT}
docker-compose.yml: Use environment variable for port mapping

ports:
  - "${PORT:-8080}:${PORT:-8080}"
environment:
  - PORT=${PORT:-8080}
Testing Instructions
Without .env file (default behavior):

make run
# Server starts on port 8080
With custom port in .env:

echo "PORT=8081" >> .env
make run
# Server starts on port 8081
With Docker Compose:

PORT=8082 docker-compose up
# Server starts on port 8082
Additional Notes
If no port is specified, falls back to 8080 for backward compatibility
Configuration cascades through all infrastructure (app, Docker, Docker Compose)
Docker configuration uses the same environment variable, ensuring consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced dynamic port configuration: The application now leverages an environment variable to determine its running port. The default remains 8080, but it can be easily overridden at runtime for more flexible deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->